### PR TITLE
Replaced npm start with npm run dev in Readme to run application in local

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install Techies Lodge, follow these steps:
 1. Clone the repository: `git clone https://github.com/singhjaspreetb/Techies-Lodge.git`
 2. Navigate to the repository directory: `cd Techies-Lodge`
 3. Install dependencies: `npm install`
-4. Start the application: `npm start`
+4. Start the application: `npm run dev`
 
 The application should now be running on your local machine.
 


### PR DESCRIPTION
 Replaced `npm start` with `npm run dev` in Readme.md to run the application in local because ` npm start` script is missing in package.json.
<img width="806" alt="Screenshot 2023-11-24 at 11 23 56 AM" src="https://github.com/singhjaspreetb/Techies-Lodge/assets/30206849/e866729b-85bc-4a92-9c71-d7b7fe68bd03">
